### PR TITLE
Portability

### DIFF
--- a/splitspy/graph/draw.py
+++ b/splitspy/graph/draw.py
@@ -21,6 +21,20 @@ def draw(outfile: str, graph: Graph, label_angles: [float] = None, fit: float = 
          width: int = 1000, height: int = 1000,
          m_left: int = 150, m_right: int = 150, m_top: int = 150, m_bot: int = 150,
          font_name: str = "Arial", font_size: int = 12, scale_factor: int =5) -> None:
+    im = do_draw(graph=graph, label_angles=label_angles, fit=fit,
+         width=width, height=height,
+         m_left=m_left, m_right=m_right, m_top=m_top, m_bot=m_bot,
+         font_name=font_name, font_size=font_size, scale_factor=scale_factor)
+    if outfile is None or outfile == "":
+        im.show()
+    else:
+        im.save(outfile)
+
+
+def do_draw(graph: Graph, label_angles: [float] = None, fit: float = -1.0,
+         width: int = 1000, height: int = 1000,
+         m_left: int = 150, m_right: int = 150, m_top: int = 150, m_bot: int = 150,
+         font_name: str = "Arial", font_size: int = 12, scale_factor: int =5) -> Image:
 
     width *= scale_factor
     height *= scale_factor
@@ -80,10 +94,7 @@ def draw(outfile: str, graph: Graph, label_angles: [float] = None, fit: float = 
             pos = __label_pos(v.label, font_size, angle, points[v], boxes)
             im_draw.text(pos, v.label, font=font, fill=black)
 
-    if outfile is None or outfile == "":
-        im.show()
-    else:
-        im.save(outfile)
+    return im
 
 
 def __label_pos(label: str, font_size: int, angle: float, pt: Tuple[float,float], boxes: [[Tuple[float,float], float, float]]) -> Tuple[float,float]:

--- a/splitspy/graph/draw.py
+++ b/splitspy/graph/draw.py
@@ -20,7 +20,7 @@ __author__ = 'Daniel H. Huson'
 def draw(outfile: str, graph: Graph, label_angles: [float] = None, fit: float = -1.0,
          width: int = 1000, height: int = 1000,
          m_left: int = 150, m_right: int = 150, m_top: int = 150, m_bot: int = 150,
-         font_size: int = 12, scale_factor: int =5) -> None:
+         font_name: str = "Arial", font_size: int = 12, scale_factor: int =5) -> None:
 
     width *= scale_factor
     height *= scale_factor
@@ -53,11 +53,11 @@ def draw(outfile: str, graph: Graph, label_angles: [float] = None, fit: float = 
 
     im_draw = ImageDraw.Draw(im)
 
-    font = ImageFont.truetype("Arial",size=font_size)
+    font = ImageFont.truetype(font_name, size=font_size)
     black = (0, 0, 0)
 
     if fit != -1:
-        im_draw.text((40*scale_factor, 10*scale_factor), "Fit: " + ("{:.2f}".format(fit)), font=ImageFont.truetype("Arial",size=10*scale_factor), fill=black)
+        im_draw.text((40*scale_factor, 10*scale_factor), "Fit: " + ("{:.2f}".format(fit)), font=ImageFont.truetype(font_name, size=10*scale_factor), fill=black)
 
     center = (0.5 * width, 0.5 * height)
 

--- a/splitspy/graph/graph.py
+++ b/splitspy/graph/graph.py
@@ -340,7 +340,7 @@ class Graph(object):
                       sep="", end="", file=outs)
             if v.info is not None:
                 print(" {", v.info, "}", sep="", end="", file=outs)
-            print()
+            print(file=outs)
 
         for e in self.edges():
             print(e.src().id(), e.tar().id(), end="", file=outs)
@@ -348,7 +348,7 @@ class Graph(object):
                 print(" [", "{:.6f}".format(e.weight), "]", sep="", end="", file=outs)
             if e.info is not None:
                 print(" {", e.info, "}", sep="", end="", file=outs)
-            print()
+            print(file=outs)
 
         if outs != sys.stdout:
             outs.close()

--- a/splitspy/nnet/nnet_algo.py
+++ b/splitspy/nnet/nnet_algo.py
@@ -16,20 +16,27 @@ __author__ = "David J. Bryant and Daniel H. Huson"
 from splitspy.nnet import nnet_cycle, nnet_splits, nnet_splits_lp
 
 
-def neighbor_net(labels: [str], mat: [[float]], cutoff=0.0001, mode: str = "CLS") -> Tuple[list, list]:
-    a = time.perf_counter()
-    cycle = nnet_cycle.compute(labels, mat)
-    b = time.perf_counter()
-    print(f"Computed circular order in {b-a:0.4f} seconds")
+def neighbor_net(labels: [str], mat: [[float]], cutoff=0.0001, mode: str = "CLS", verbose: bool = True) -> Tuple[list, list]:
+    if verbose:
+        a = time.perf_counter()
 
-    a = time.perf_counter()
+    cycle = nnet_cycle.compute(labels, mat)
+
+    if verbose:
+        b = time.perf_counter()
+        print(f"Computed circular order in {b-a:0.4f} seconds")
+
+    if verbose:
+        a = time.perf_counter()
+
     if mode == "LP":
         splits = nnet_splits_lp.compute(len(labels), mat, cycle, cutoff)
     else:
         constrained = (mode != "OLS")
         splits = nnet_splits.compute(len(labels), mat, cycle, cutoff, constrained)
 
-    b = time.perf_counter()
-    print(f"Computed splits in {b-a:0.4f} seconds (mode={mode})")
+    if verbose:
+        b = time.perf_counter()
+        print(f"Computed splits in {b-a:0.4f} seconds (mode={mode})")
 
     return cycle, splits

--- a/splitspy/nnet/nnet_splits_lp.py
+++ b/splitspy/nnet/nnet_splits_lp.py
@@ -17,7 +17,7 @@ from splitspy.splits.basic_split import *
 __author__ = "Daniel H. Huson"
 
 
-def compute(n_tax: int, mat: np.array, cycle: [int], cutoff=0.00001) -> [Split]:
+def compute(n_tax: int, mat: np.array, cycle: [int], cutoff=0.00001, verbose: bool = True) -> [Split]:
     """ compute splits and their weights using Linear Program
         Parameters
         ----------
@@ -82,7 +82,8 @@ def compute(n_tax: int, mat: np.array, cycle: [int], cutoff=0.00001) -> [Split]:
             split = Split(src.part1(),src.part2(),res.x[s])
             result.append(split)
 
-    print(f"Delta: {total+res.fun:0.4f}")
+    if verbose:
+        print(f"Delta: {total+res.fun:0.4f}")
 
     return result
 

--- a/splitspy/outline.py
+++ b/splitspy/outline.py
@@ -57,6 +57,7 @@ def main():
         --m_right=MARGIN    right margin
         --m_top=MARGIN      top margin
         --m_bot=MARGIN      bottom margin
+        --font_name=F_NAME  font name or path
         --font_size=F_SIZE  font size
 
     Input format:
@@ -123,6 +124,8 @@ def main():
                         metavar="MARGIN")
     win_opts.add_option("--m_bot", default=100, action="store", dest="m_bot", help="bottom margin", type="int",
                         metavar="MARGIN")
+    win_opts.add_option("--font_name", default="Arial", action="store", dest="font_name", help="font size", type="str",
+                        metavar="FONTNAME")
     win_opts.add_option("--font_size", default=12, action="store", dest="font_size", help="font size", type="int",
                         metavar="SIZE")
 
@@ -155,13 +158,13 @@ def main():
     run(labels, matrix, outfile=options.outfile, nexus_file=options.nexus_file, graph_file=options.graph_file,
         mode=options.mode, cutoff=options.cutoff, rooted=options.rooted, alt=options.alt, out_grp=out_grp,
         win_width=options.win_width,win_height=options.win_height, m_left=options.m_left, m_right=options.m_right,
-        m_top=options.m_top, m_bot=options.m_bot,font_size=options.font_size)
+        m_top=options.m_top, m_bot=options.m_bot, font_name=options.font_name, font_size=options.font_size)
 
 
 def run(labels: [str], matrix: [[float]], outfile: str = "", nexus_file: str = "", graph_file: str = "",
         mode: str = "CLS", cutoff: float = 0.0,
         rooted: bool = False, alt: bool = False, out_grp: Set[int] = None, win_width: int = 1000, win_height: int = 800,
-        m_left: int = 100, m_right: int = 100, m_top: int = 100, m_bot: int = 100, font_size: int = 12) -> None:
+        m_left: int = 100, m_right: int = 100, m_top: int = 100, m_bot: int = 100, font_name: str = "Arial", font_size: int = 12) -> None:
 
 
     # distances.write(labels, matrix, outfile)
@@ -178,7 +181,7 @@ def run(labels: [str], matrix: [[float]], outfile: str = "", nexus_file: str = "
     if graph_file != "":
         graph.write_tgf(outfile=graph_file)
 
-    draw.draw(outfile, graph, angles, fit, win_width, win_height,m_left, m_right, m_top, m_bot, font_size)
+    draw.draw(outfile, graph, angles, fit, win_width, win_height, m_left, m_right, m_top, m_bot, font_name, font_size)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Made a few modifications which allow using this tool in a more portable way:
- Allow custom font names: "Arial" only works on windows
- Added "inner" function do_draw, which lets us handle the image in a custom way (e.g., displaying in a jupyter notebook)
- Add parameter disabling prints from algorithm functions, to allow running them in a larger loop

Also fixed a bug in TGF writing, where the newlines were written to stdout and not to the file